### PR TITLE
bug fix in evaluation

### DIFF
--- a/lerf/lerf.py
+++ b/lerf/lerf.py
@@ -206,10 +206,11 @@ class LERFModel(NerfactoModel):
 
     def get_loss_dict(self, outputs, batch, metrics_dict=None):
         loss_dict = super().get_loss_dict(outputs, batch, metrics_dict)
-        loss_dict["clip_loss"] = self.config.clip_loss_weight * torch.nn.functional.huber_loss(
-            outputs["clip"], batch["clip"], delta=1.25
-        )
-        loss_dict["dino_loss"] = torch.nn.functional.mse_loss(outputs["dino"], batch["dino"])
+        if self.training:
+            loss_dict["clip_loss"] = self.config.clip_loss_weight * torch.nn.functional.huber_loss(
+                outputs["clip"], batch["clip"], delta=1.25
+            )
+            loss_dict["dino_loss"] = torch.nn.functional.mse_loss(outputs["dino"], batch["dino"])
         return loss_dict
 
     def get_param_groups(self) -> Dict[str, List[Parameter]]:


### PR DESCRIPTION
In evaluation, clip and dino information is not contained in data batch and model outputs, so they should not be evaluated.

Currently, the evaluation will raise errors:
```bash
Traceback (most recent call last):
  File "/DATA1/yingda/miniconda3/envs/lerf/bin/ns-train", line 8, in <module>
    sys.exit(entrypoint())
  File "/DATA1/yingda/code/nerfstudio/scripts/train.py", line 254, in entrypoint
    main(
  File "/DATA1/yingda/code/nerfstudio/scripts/train.py", line 240, in main
    launch(
  File "/DATA1/yingda/code/nerfstudio/scripts/train.py", line 173, in launch
    main_func(local_rank=0, world_size=world_size, config=config)
  File "/DATA1/yingda/code/nerfstudio/scripts/train.py", line 88, in train_loop
    trainer.train()
  File "/DATA1/yingda/code/nerfstudio/nerfstudio/engine/trainer.py", line 243, in train
    self.eval_iteration(step)
  File "/DATA1/yingda/code/nerfstudio/nerfstudio/utils/decorators.py", line 70, in wrapper
    ret = func(self, *args, **kwargs)
  File "/DATA1/yingda/code/nerfstudio/nerfstudio/utils/profiler.py", line 43, in wrapper
    ret = func(*args, **kwargs)
  File "/DATA1/yingda/code/nerfstudio/nerfstudio/engine/trainer.py", line 424, in eval_iteration
    _, eval_loss_dict, eval_metrics_dict = self.pipeline.get_eval_loss_dict(step=step)
  File "/DATA1/yingda/code/nerfstudio/nerfstudio/utils/profiler.py", line 43, in wrapper
    ret = func(*args, **kwargs)
  File "/DATA1/yingda/code/nerfstudio/nerfstudio/pipelines/base_pipeline.py", line 300, in get_eval_loss_dict
    loss_dict = self.model.get_loss_dict(model_outputs, batch, metrics_dict)
  File "/DATA1/yingda/code/lerf/lerf/lerf.py", line 212, in get_loss_dict
    outputs["clip"], batch["clip"], delta=1.25
KeyError: 'clip'
```

PS: It will happen only when`@check_eval_enabled` is True, i.e., `wandb` or `tensorboard` is enabled