### PR TITLE
Make LERF compatible with DINOv2

### DIFF
--- a/lerf/data/lerf_datamanager.py
+++ b/lerf/data/lerf_datamanager.py
@@ -81,7 +81,8 @@ class LERFDataManager(VanillaDataManager):  # pylint: disable=abstract-method
 
         cache_dir = f"outputs/{self.config.dataparser.data.name}"
         clip_cache_path = Path(osp.join(cache_dir, f"clip_{self.image_encoder.name}"))
-        dino_cache_path = Path(osp.join(cache_dir, "dino.npy"))
+        dino_name = DinoDataloader.dino_model_type
+        dino_cache_path = Path(osp.join(cache_dir, f"dino_{dino_name}.npy"))
         # NOTE: cache config is sensitive to list vs. tuple, because it checks for dict equality
         self.dino_dataloader = DinoDataloader(
             image_list=images,

--- a/lerf/data/utils/dino_dataloader.py
+++ b/lerf/data/utils/dino_dataloader.py
@@ -4,11 +4,15 @@ import torch
 from lerf.data.utils.dino_extractor import ViTExtractor
 from lerf.data.utils.feature_dataloader import FeatureDataloader
 from tqdm import tqdm
+import torchvision.transforms as transforms
 
 
 class DinoDataloader(FeatureDataloader):
     dino_model_type = "dino_vits8"
     dino_stride = 8
+    # # For dinov2, use this:
+    # dino_model_type = "dinov2_vitb14"
+    # dino_stride = 14
     dino_load_size = 500
     dino_layer = 11
     dino_facet = "key"
@@ -30,6 +34,12 @@ class DinoDataloader(FeatureDataloader):
 
         dino_embeds = []
         for image in tqdm(preproc_image_lst, desc="dino", total=len(image_list), leave=False):
+            # image nees to be resized s.t. H, W are divisible by dino_stride
+            if "dinov2" in self.dino_model_type:
+                image = transforms.Resize((
+                    (image.shape[1]//self.dino_stride)*self.dino_stride,
+                    (image.shape[2]//self.dino_stride)*self.dino_stride,
+                    ))(image)
             with torch.no_grad():
                 descriptors = extractor.extract_descriptors(
                     image.unsqueeze(0),

--- a/lerf/data/utils/dino_dataloader.py
+++ b/lerf/data/utils/dino_dataloader.py
@@ -27,6 +27,11 @@ class DinoDataloader(FeatureDataloader):
     ):
         assert "image_shape" in cfg
         super().__init__(cfg, device, image_list, cache_path)
+        # Do distillation-preprocessing as noted in N3F:
+        # The features are then L2-normalized and reduced with PCA to 64 dimensions before distillation.
+        data_shape = self.data.shape
+        self.data = self.data / self.data.norm(dim=-1, keepdim=True) 
+        self.data = torch.pca_lowrank(self.data.reshape(-1, data_shape[-1]), q=64)[0].reshape((*data_shape[:-1], 64))
 
     def create(self, image_list):
         extractor = ViTExtractor(self.dino_model_type, self.dino_stride)

--- a/lerf/lerf.py
+++ b/lerf/lerf.py
@@ -51,6 +51,8 @@ class LERFModel(NerfactoModel):
             clip_n_dims=self.image_encoder.embedding_dim,
         )
 
+        self.n_clusters = ViewerSlider("n_clusters", 6, 2, 20, 1)
+
         # populate some viewer logic
         # TODO use the values from this code to select the scale
         # def scale_cb(element):
@@ -159,6 +161,19 @@ class LERFModel(NerfactoModel):
                 )
                 outputs["raw_relevancy"] = max_across  # N x B x 1
                 outputs["best_scales"] = best_scales.to(self.device)  # N
+            
+            from fast_pytorch_kmeans import KMeans
+            n_clusters = self.n_clusters.value
+            dino_feats = self.renderer_mean(embeds=lerf_field_outputs[LERFFieldHeadNames.DINO], weights=lerf_weights.detach())
+            kmeans = KMeans(n_clusters=n_clusters, verbose=0)
+            dino_labels = kmeans.fit_predict(dino_feats)
+            dino_labels = dino_labels / dino_labels.max()
+            outputs["dino_kmeans"] = dino_labels[...,None]
+
+            dino_feats_pca = torch.pca_lowrank(dino_feats, q=3)[0]
+            dino_feats_pca = dino_feats_pca - dino_feats_pca.min(dim=0, keepdim=True).values
+            dino_feats_pca = dino_feats_pca / dino_feats_pca.max(dim=0, keepdim=True).values
+            outputs["dino_pca"] = dino_feats_pca
 
         return outputs
 

--- a/lerf/lerf_field.py
+++ b/lerf/lerf_field.py
@@ -58,7 +58,9 @@ class LERFField(Field):
 
         self.dino_net = tcnn.Network(
             n_input_dims=tot_out_dims,
-            n_output_dims=384,
+            n_output_dims=64,
+            # n_output_dims=384,
+            # n_output_dims=768,
             network_config={
                 "otype": "CutlassMLP",
                 "activation": "ReLU",


### PR DESCRIPTION
Added capability to use DINOv2 models

(Using implementation/torchhub as described by https://github.com/facebookresearch/dinov2)

TODOs:
 - [ ] Compare/contrast DINO vs. DINOv2 features
 - [ ] Add DINO feature visualization(?) -- for the compare/contrast. Initial implementation cause the colors to be inconsistent across renders, so it feels confusing/disorienting. 
 - [ ] Add compatibility for ViT-B/L/G DINO versions (currently dino-field embedding out hardcoded to 384)