### PR TITLE
add missing argument grad_scaler for LERFPipeline

### DIFF
--- a/lerf/lerf_pipeline.py
+++ b/lerf/lerf_pipeline.py
@@ -1,9 +1,10 @@
 import typing
 from dataclasses import dataclass, field
-from typing import Literal, Type
+from typing import Literal, Optional, Type
 
 import torch.distributed as dist
 from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.cuda.amp.grad_scaler import GradScaler
 
 from nerfstudio.configs import base_config as cfg
 from nerfstudio.models.base_model import ModelConfig
@@ -42,6 +43,7 @@ class LERFPipeline(VanillaPipeline):
         test_mode: Literal["test", "val", "inference"] = "val",
         world_size: int = 1,
         local_rank: int = 0,
+        grad_scaler: Optional[GradScaler] = None,
     ):
         super(VanillaPipeline, self).__init__()
         self.config = config


### PR DESCRIPTION
Hi, @kerrj! 
Thank you for sharing this great work!

I noticed that with the recent update to nerf-studio, there have been some changes made to the arguments in the VanillaPipeline. (nerfstudio-project/nerfstudio@a8bce87ada9124bf5f2e0b73d5d918f8cf9f1c35)
Unfortunately, this modification has led to an error stating `TypeError: init() got an unexpected keyword argument 'grad_scaler'.`
To resolve this issue, I manually added the 'grad_scaler' argument to the LERFPipeline.

Once again, thank you for your valuable work and for considering my suggestion.