### PR TITLE
Small fixes to make LeRF work with latest Nerfstudio

### DIFF
--- a/lerf/data/utils/dino_extractor.py
+++ b/lerf/data/utils/dino_extractor.py
@@ -154,7 +154,7 @@ class ViTExtractor:
         #     pil_image = transforms.Resize(load_size, interpolation=transforms.InterpolationMode.LANCZOS)(pil_image)
         prep = transforms.Compose([
             # transforms.ToTensor(),
-            transforms.Resize(load_size),
+            transforms.Resize(load_size, antialias=None),
             transforms.Normalize(mean=self.mean, std=self.std)
         ])
         prep_img = prep(image)[None, ...]

--- a/lerf/lerf_pipeline.py
+++ b/lerf/lerf_pipeline.py
@@ -1,8 +1,9 @@
 import typing
 from dataclasses import dataclass, field
-from typing import Literal, Type
+from typing import Literal, Type, Optional
 
 import torch.distributed as dist
+from torch.cuda.amp.grad_scaler import GradScaler
 from torch.nn.parallel import DistributedDataParallel as DDP
 
 from nerfstudio.configs import base_config as cfg
@@ -42,6 +43,7 @@ class LERFPipeline(VanillaPipeline):
         test_mode: Literal["test", "val", "inference"] = "val",
         world_size: int = 1,
         local_rank: int = 0,
+        grad_scaler: Optional[GradScaler] = None,
     ):
         super(VanillaPipeline, self).__init__()
         self.config = config
@@ -66,6 +68,7 @@ class LERFPipeline(VanillaPipeline):
             num_train_data=len(self.datamanager.train_dataset),
             metadata=self.datamanager.train_dataset.metadata,
             image_encoder=self.image_encoder,
+            grad_scaler=grad_scaler,
         )
         self.model.to(device)
 


### PR DESCRIPTION
Made two small fixes:

1. Add grad_scaler to lerf pipeline so that no errors occur in the latest Nerfstudio Trainer.
2. In dino extractor, added extra parameter antialias=None to stop annoying warning messages regarding resize(). Similar to: https://github.com/nerfstudio-project/nerfstudio/pull/2033

