### PR TITLE
Fix missing `import sys` in lerf_field.py

### DIFF
--- a/lerf/lerf_field.py
+++ b/lerf/lerf_field.py
@@ -6,6 +6,7 @@ from lerf.lerf_fieldheadnames import LERFFieldHeadNames
 from torch import nn, Tensor
 from torch.nn.parameter import Parameter
 from jaxtyping import Float
+import sys
 
 from nerfstudio.cameras.rays import RaySamples
 from nerfstudio.data.scene_box import SceneBox


### PR DESCRIPTION
When CUDA is not available, `lerf_field.py` prints to `sys.stderr` upon import. However, the file is missing an import to `sys`, thus causing an exception to be raised and failing the import.

When running `ns-install-cli` as part of building a Docker container (where CUDA is only available during runtime, not during build), the above error means `ns-install-cli` fails and prevents installing the lerf code in the Docker container.