### PR TITLE
Dataclassses default initialization

### DIFF
--- a/lerf/lerf_pipeline.py
+++ b/lerf/lerf_pipeline.py
@@ -27,11 +27,11 @@ class LERFPipelineConfig(VanillaPipelineConfig):
 
     _target: Type = field(default_factory=lambda: LERFPipeline)
     """target class to instantiate"""
-    datamanager: LERFDataManagerConfig = LERFDataManagerConfig()
+    datamanager: LERFDataManagerConfig = field(default_factory=lambda: LERFDataManagerConfig())
     """specifies the datamanager config"""
-    model: ModelConfig = LERFModelConfig()
+    model: ModelConfig = field(default_factory=lambda: LERFModelConfig())
     """specifies the model config"""
-    network: BaseImageEncoderConfig = BaseImageEncoderConfig()
+    network: BaseImageEncoderConfig = field(default_factory=lambda: BaseImageEncoderConfig())
     """specifies the vision-language network config"""
 
 


### PR DESCRIPTION
Initialization errors out with newer versions of the python interpreter. This should be equivalent.